### PR TITLE
Bugfix for photos in public albums

### DIFF
--- a/getPhoto.php
+++ b/getPhoto.php
@@ -96,7 +96,7 @@ function getPhoto($database, $type, $photoUrl, $isAdmin)
 		return $photo;
 	} else {
 		# Check if album public
-		$album	= new Album($database, null, null, $photo->album);
+		$album	= new Album($photo->album);
 		$agP	= $album->getPublic();
 
 		if ($agP===true) return $photo;


### PR DESCRIPTION
Album() only takes one argument which is the album ID. Having the constructor call the old way makes getPublic() always returning _false_.

Tested with the current Lychee version.
